### PR TITLE
Disable search text modification when using filters for searching

### DIFF
--- a/modify_search_text/__init__.py
+++ b/modify_search_text/__init__.py
@@ -26,6 +26,7 @@ def modify_search_text(context: SearchContext) -> None:
         context.search = remove_disable_command_from_search_text_if_necessary(context.search)
         return
 
+    # TODO: Is this really a *feature* we need to have? Isn't this already taken on by the filter `nc:'?
     context.search = replace_vowels.replace_vowels_in_search_text(context.search)
     context.search = f"nc:{context.search}"
 

--- a/modify_search_text/__init__.py
+++ b/modify_search_text/__init__.py
@@ -10,6 +10,8 @@ PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License along
 with this program. If not, see <https://www.gnu.org/licenses/>
 """
+import re
+
 from aqt.browser import SearchContext
 
 from .. import replace_vowels
@@ -22,7 +24,8 @@ def modify_search_text(context: SearchContext) -> None:
 
     search_text_modification_disabled_command = settings.read('disable_modification_of_search_text_by_addon_command')
     if is_more_than_one_word(context.search) \
-            or search_text_modification_disabled_by_user(context.search, search_text_modification_disabled_command):
+            or search_text_modification_disabled_by_user(context.search, search_text_modification_disabled_command) \
+            or custom_search_filter_has_been_applied_by_anki_or_by_user(context.search):
         context.search = context.search.replace(search_text_modification_disabled_command, "")
         return
 
@@ -32,6 +35,10 @@ def modify_search_text(context: SearchContext) -> None:
 
 def is_more_than_one_word(search: str) -> bool:
     return len(search.split(" ")) > 1
+
+
+def custom_search_filter_has_been_applied_by_anki_or_by_user(search: str) -> re.Match:
+    return re.search(r'\w+:\w+', search)
 
 
 def search_text_modification_disabled_by_user(search: str, search_text_modification_disabled_command: str) -> bool:

--- a/modify_search_text/__init__.py
+++ b/modify_search_text/__init__.py
@@ -22,24 +22,34 @@ def modify_search_text(context: SearchContext) -> None:
     if context.ids:
         return
 
-    search_text_modification_disabled_command = settings.read('disable_modification_of_search_text_by_addon_command')
-    if is_more_than_one_word(context.search) \
-            or search_text_modification_disabled_by_user(context.search, search_text_modification_disabled_command) \
-            or custom_search_filter_has_been_applied_by_anki_or_by_user(context.search):
-        context.search = context.search.replace(search_text_modification_disabled_command, "")
+    if should_not_modify_search_text(context.search):
+        context.search = remove_disable_command_from_search_text_if_necessary(context.search)
         return
 
     context.search = replace_vowels.replace_vowels_in_search_text(context.search)
     context.search = f"nc:{context.search}"
 
 
+def should_not_modify_search_text(search: str) -> bool:
+    return is_more_than_one_word(search) \
+        or search_text_modification_disabled_by_user(search) \
+        or advanced_search_filter_has_been_applied(search)
+
+
 def is_more_than_one_word(search: str) -> bool:
     return len(search.split(" ")) > 1
 
 
-def custom_search_filter_has_been_applied_by_anki_or_by_user(search: str) -> re.Match:
+def advanced_search_filter_has_been_applied(search: str) -> re.Match:
+    # Matches strings like `id:123', `nid:123', `nc:bonjour', ...
     return re.search(r'\w+:\w+', search)
 
 
-def search_text_modification_disabled_by_user(search: str, search_text_modification_disabled_command: str) -> bool:
-    return search_text_modification_disabled_command in search
+def search_text_modification_disabled_by_user(search: str) -> bool:
+    disable_command = settings.read('disable_modification_of_search_text_by_addon_command')
+    return disable_command in search
+
+
+def remove_disable_command_from_search_text_if_necessary(search: str) -> str:
+    disable_command = settings.read('disable_modification_of_search_text_by_addon_command')
+    return search.replace(disable_command, "")


### PR DESCRIPTION
- Disable search text modification when using filters for searching

Filters like `id:123`, `nid:123` or `nc:bonjour`
will not be prefixed with `nc:`, resulting in
searches like `nc🆔123`, `nc:nid:123` or
`nc:nc:bonjour`, which did not return any matches.
This was a severe problem, because Anki searches
for the nid when displaying the history of added
cards.

- Extract if statement for modifying the search text
- Add todo item for modifying the search text
