### PR TITLE
Allow specifying deck name in addition to note type

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,8 +19,11 @@ from anki import hooks_gen
 
 from .replace_vowels import replace_vowels_in_note
 from .modify_search_text import modify_search_text
+from .replace_vowels.utils import set_new_deck_name
 
 
 gui_hooks.browser_will_search.append(modify_search_text)
 gui_hooks.editor_did_unfocus_field.append(replace_vowels_in_note)
 hooks_gen.note_will_flush.append(lambda note: replace_vowels_in_note(False, note, 1))
+
+gui_hooks.add_cards_did_change_deck.append(set_new_deck_name)

--- a/config.json
+++ b/config.json
@@ -3,6 +3,11 @@
     "latin",
     "latein"
   ],
+  "latin_deck_names": [
+    "Latein Vokabeln",
+    "latin vocab",
+    "latin vocabulary"
+  ],
   "long_vowels": {
     "a": "ā", "e": "ē", "i": "ī", "o": "ō", "u": "ū", "y": "ȳ"
   },

--- a/config.md
+++ b/config.md
@@ -8,6 +8,11 @@ You are free to customize these settings for changing how advocator behaves.
    type you are currently using for writing your words. This add-on will only 
    replace vowels when the note type for this word contains one of these 
    strings. Defaults are `latin` and `latein` (which is German for *latin*).
+ - **latin_deck_names**: Advocator not only searches for `latin_note_types`, but
+   also checks if the name of the deck matches a name specified in this array. 
+   This way *Advocator* works in a deck no matter what note type you are 
+   currently using. Defaults are `Latein Vokabeln` (German), `latin vocab` and
+   `latin vocabulary`.
  - **long_vowel_command_symbol**: When Advocator finds a vowel 
    (`a, e, i, o, u or y`) in your current note with this character exactly after
    it, the add-on will replace it with the corresponding long vowel 

--- a/replace_vowels/replace_vowels_in_note.py
+++ b/replace_vowels/replace_vowels_in_note.py
@@ -13,7 +13,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 from anki.notes import Note
 
 from .update_vowels import update_vowels
-from .utils import is_latin_model, is_note_of_explicitly_specified_deck, note_has_been_updated
+from .utils import is_latin_model, is_latin_deck, note_has_been_updated
 
 from .. import settings
 
@@ -43,5 +43,5 @@ def replace_vowels_in_note(_changed: bool, note: Note, _current_field_idx: int) 
 
 def do_not_replace_vowels_in_note(note: Note) -> bool:
     return not (
-            is_latin_model(note) or is_note_of_explicitly_specified_deck(note)
+            is_latin_model(note) or is_latin_deck(note)
     )

--- a/replace_vowels/replace_vowels_in_note.py
+++ b/replace_vowels/replace_vowels_in_note.py
@@ -13,13 +13,13 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 from anki.notes import Note
 
 from .update_vowels import update_vowels
-from .utils import is_latin_model, note_has_been_updated
+from .utils import is_latin_model, is_note_of_explicitly_specified_deck, note_has_been_updated
 
 from .. import settings
 
 
 def replace_vowels_in_note(_changed: bool, note: Note, _current_field_idx: int) -> bool:
-    if not is_latin_model(note):
+    if not is_latin_model(note) and not is_note_of_explicitly_specified_deck(note):
         return False
 
     lower_short_vowels = settings.read('short_vowels')

--- a/replace_vowels/replace_vowels_in_note.py
+++ b/replace_vowels/replace_vowels_in_note.py
@@ -19,7 +19,7 @@ from .. import settings
 
 
 def replace_vowels_in_note(_changed: bool, note: Note, _current_field_idx: int) -> bool:
-    if not is_latin_model(note) and not is_note_of_explicitly_specified_deck(note):
+    if do_not_replace_vowels_in_note(note):
         return False
 
     lower_short_vowels = settings.read('short_vowels')
@@ -39,3 +39,9 @@ def replace_vowels_in_note(_changed: bool, note: Note, _current_field_idx: int) 
 
         note[name] = value
         return True
+
+
+def do_not_replace_vowels_in_note(note: Note) -> bool:
+    return not (
+            is_latin_model(note) or is_note_of_explicitly_specified_deck(note)
+    )

--- a/replace_vowels/utils.py
+++ b/replace_vowels/utils.py
@@ -32,7 +32,7 @@ def is_latin_model(note: Note) -> bool:
     return any([latin_note_type in note_type for latin_note_type in latin_note_types])
 
 
-def is_note_of_explicitly_specified_deck(_: Note) -> bool:
+def is_latin_deck(_: Note) -> bool:
     global changed_deck_name
     latin_deck_names = settings.read('latin_deck_names')
 

--- a/replace_vowels/utils.py
+++ b/replace_vowels/utils.py
@@ -34,15 +34,13 @@ def is_latin_model(note: Note) -> bool:
 
 def is_note_of_explicitly_specified_deck(_: Note) -> bool:
     global changed_deck_name
-
-    # TODO: Read this value from the settings
-    explicitly_defined_decks = ["latin test deck", "Latein Vokabeln"]
+    latin_deck_names = settings.read('latin_deck_names')
 
     default_deck_id = mw.col.decks.get_current_id()
     default_deck_name = mw.col.decks.name(default_deck_id)
     current_deck_name = changed_deck_name if changed_deck_name else default_deck_name
 
-    return any([latin_deck in current_deck_name for latin_deck in explicitly_defined_decks])
+    return any([latin_deck in current_deck_name for latin_deck in latin_deck_names])
 
 
 def set_new_deck_name(new_deck_id: int) -> None:

--- a/replace_vowels/utils.py
+++ b/replace_vowels/utils.py
@@ -11,6 +11,7 @@ You should have received a copy of the GNU Affero General Public License along
 with this program. If not, see <https://www.gnu.org/licenses/>
 """
 from anki.notes import Note
+from aqt import mw
 
 from .. import settings
 
@@ -29,3 +30,24 @@ def is_latin_model(note: Note) -> bool:
     note_type = note.note_type()['name'].lower()
 
     return any([latin_note_type in note_type for latin_note_type in latin_note_types])
+
+
+def is_note_of_explicitly_specified_deck(_: Note) -> bool:
+    global changed_deck_name
+
+    # TODO: Read this value from the settings
+    explicitly_defined_decks = ["latin test deck", "Latein Vokabeln"]
+
+    default_deck_id = mw.col.decks.get_current_id()
+    default_deck_name = mw.col.decks.name(default_deck_id)
+    current_deck_name = changed_deck_name if changed_deck_name else default_deck_name
+
+    return any([latin_deck in current_deck_name for latin_deck in explicitly_defined_decks])
+
+
+def set_new_deck_name(new_deck_id: int) -> None:
+    global changed_deck_name
+    changed_deck_name = mw.col.decks.name(new_deck_id)
+
+
+changed_deck_name = ""


### PR DESCRIPTION
By also checking the deck name for a list of strings previously defined by the user, this will simplify the usage of Advocator.

Users won't have to worry about vowels not getting replaced because they were using the wrong note type, because vowels will now be replaced for the whole deck.
